### PR TITLE
Deprecate module website_event_legal_acceptance.

### DIFF
--- a/website_event_legal_acceptance/README.rst
+++ b/website_event_legal_acceptance/README.rst
@@ -2,3 +2,19 @@ Website Legal Acceptance
 ========================
 
 Add legal acceptance to events.
+
+Deprecation
+-----------
+
+This module is **DEPRECATED** in favor of these incoming modules:
+
+- `website_sale_product_legal <https://github.com/OCA/e-commerce/pull/72>`_
+- `website_event_sale_legal <https://github.com/OCA/event/pull/12>`_
+
+If you were using versions previous to 8.0.2.0.0 and you want to update, follow
+these steps:
+
+1. Install both above modules.
+2. Restart your server.
+3. Update this module.
+4. Uninstall this module.

--- a/website_event_legal_acceptance/__openerp__.py
+++ b/website_event_legal_acceptance/__openerp__.py
@@ -29,15 +29,10 @@
 {
     'name': "Website Legal Acceptance",
     'category': 'Tools',
-    'version': '1.0',
+    'version': '8.0.2.0.0',
     'depends': [
-        'website_event',
-    ],
-    'data': [
-        'views/assets.xml',
-        'views/templates.xml',
-        'views/event_event_view.xml',
-        'security/ir.model.access.csv',
+        'website_sale_product_legal',
+        'website_event_sale_legal',
     ],
     'author': 'Antiun Ingenieria S.L., '
               'Serv. Tecnol. Avanzados - Pedro M. Baeza',

--- a/website_event_legal_acceptance/migrations/8.0.2.0.0/pre-migration.py
+++ b/website_event_legal_acceptance/migrations/8.0.2.0.0/pre-migration.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# © 2015 Antiun Ingeniería, S.L. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    # Fill legal terms table
+    cr.execute("""
+        INSERT INTO website_sale_product_legal_legal_term(id, name, contents)
+        SELECT id, name, description
+        FROM event_legal_template
+    """)
+
+    # Fill event and legal terms relation
+    cr.execute("""
+        INSERT INTO website_event_sale_legal_term_event_rel(
+            event_event_id,
+            website_sale_product_legal_legal_term_id)
+        SELECT id, legal_acceptance
+        FROM event_event
+        WHERE legal_acceptance IS NOT NULL
+    """)


### PR DESCRIPTION
Deprecates this module in favor of https://github.com/OCA/e-commerce/pull/72 and https://github.com/OCA/event/pull/12.

CC @rafaelbn 
