### PR TITLE
[FIX][partner_ref_unique] Work with contact deduplicator.

### DIFF
--- a/partner_ref_unique/models/res_partner.py
+++ b/partner_ref_unique/models/res_partner.py
@@ -25,7 +25,10 @@ class ResPartner(models.Model):
                 if mode == 'companies':
                     domain.append(('is_company', '=', True))
                 other = self.search(domain)
-                if other:
+
+                # active_test is False when called from
+                # base.partner.merge.automatic.wizard
+                if other and self.env.context.get("active_test", True):
                     raise ValidationError(
                         _("This reference is equal to partner '%s'") %
                         other[0].display_name)


### PR DESCRIPTION
This contraint is self-disabled when it detects by context that it is being used from the contact deduplicator.

Otherwise, the user cannot deduplicate a contact selecting the "good" one as the one without reference.

Anyway, in these cases, the check has no meaning, since it is to avoid duplicates and in this context we are currently removing them.

@Tecnativa
